### PR TITLE
[Bug fix] Fixing rule generator

### DIFF
--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -7,8 +7,8 @@ import (
 	csmodels "github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/fallard84/cs-cloud-firewall-bouncer/pkg/models"
 	"github.com/fallard84/cs-cloud-firewall-bouncer/pkg/providers"
+	"github.com/sethvargo/go-diceware/diceware"
 	log "github.com/sirupsen/logrus"
-	"github.com/zhexuany/wordGenerator"
 )
 
 type Bouncer struct {
@@ -115,8 +115,11 @@ func (f *Bouncer) getRuleToUpdate(rules []*models.FirewallRule) (*models.Firewal
 
 func (f *Bouncer) genNewRuleName() string {
 
-	random := wordGenerator.GetWords(5, 20)
-	r := fmt.Sprintf("%s-%s", f.RuleNamePrefix, strings.ToLower(strings.Join(random, "-")))
+	randomWords, err := diceware.Generate(2)
+	if err != nil {
+		log.Fatalf("not able to generate random words: %s", err.Error())
+	}
+	r := fmt.Sprintf("%s-%s", f.RuleNamePrefix, strings.ToLower(strings.Join(randomWords, "-")))
 	return r
 }
 

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -115,10 +115,7 @@ func (f *Bouncer) getRuleToUpdate(rules []*models.FirewallRule) (*models.Firewal
 
 func (f *Bouncer) genNewRuleName() string {
 
-	randomWords, err := diceware.Generate(2)
-	if err != nil {
-		log.Fatalf("not able to generate random words: %s", err.Error())
-	}
+	randomWords := diceware.MustGenerate(2)
 	r := fmt.Sprintf("%s-%s", f.RuleNamePrefix, strings.ToLower(strings.Join(randomWords, "-")))
 	return r
 }

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -1,6 +1,7 @@
 package firewall
 
 import (
+	"fmt"
 	"testing"
 
 	csmodels "github.com/crowdsecurity/crowdsec/pkg/models"
@@ -43,7 +44,8 @@ func TestBouncer_getRuleToUpdate(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		rule, rules := f.getRuleToUpdate(tests["empty"].rules)
 		assert.Contains(t, rule.Name, f.RuleNamePrefix)
-		assert.Regexp(t, "(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)", rule.Name)
+		assert.Regexp(t, "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$", rule.Name)
+		fmt.Printf("rule name: %s", rule.Name)
 		assert.Equal(t, rules[0].Name, rule.Name)
 		assert.Equal(t, models.New, rule.State)
 	})

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -43,7 +43,8 @@ func TestBouncer_getRuleToUpdate(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		rule, rules := f.getRuleToUpdate(tests["empty"].rules)
 		assert.Contains(t, rule.Name, f.RuleNamePrefix)
-		assert.Contains(t, rules[0].Name, f.RuleNamePrefix)
+		assert.Regexp(t, "(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)", rule.Name)
+		assert.Equal(t, rules[0].Name, rule.Name)
 		assert.Equal(t, models.New, rule.State)
 	})
 	t.Run("existing", func(t *testing.T) {


### PR DESCRIPTION
The previous random word generator was not properly tested with GCP and was not meeting the criteria. This is replacing it with diceware, which is actually generating random words and not just random characters. Also adding regex test to make sure GCP won't reject it. This will need to be adjusted to match other cloud providers eventually or, if difficult to have a common rule generator, extract it to the cloud provider interface.